### PR TITLE
Optimize code for performance and load times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,target=. \
-    CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.commit=$(git rev-parse HEAD) -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     -o /bin/github-mcp-server cmd/github-mcp-server/main.go
 
 # Make a stage to run the app

--- a/cmd/github-mcp-server/generate_docs.go
+++ b/cmd/github-mcp-server/generate_docs.go
@@ -1,3 +1,5 @@
+//go:build docgen
+
 package main
 
 import (

--- a/internal/ghmcp/server.go
+++ b/internal/ghmcp/server.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/github/github-mcp-server/pkg/errors"
 	"github.com/github/github-mcp-server/pkg/github"
@@ -55,21 +57,39 @@ func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
 		return nil, fmt.Errorf("failed to parse API host: %w", err)
 	}
 
-	// Construct our REST client
-	restClient := gogithub.NewClient(nil).WithAuthToken(cfg.Token)
+	// Construct tuned HTTP transport
+	defaultDialer := &net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	optimizedTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           defaultDialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	// Construct our REST client with timeouts
+	restHTTPClient := &http.Client{
+		Transport: optimizedTransport,
+		Timeout:   30 * time.Second,
+	}
+	restClient := gogithub.NewClient(restHTTPClient).WithAuthToken(cfg.Token)
 	restClient.UserAgent = fmt.Sprintf("github-mcp-server/%s", cfg.Version)
 	restClient.BaseURL = apiHost.baseRESTURL
 	restClient.UploadURL = apiHost.uploadURL
 
-	// Construct our GraphQL client
-	// We're using NewEnterpriseClient here unconditionally as opposed to NewClient because we already
-	// did the necessary API host parsing so that github.com will return the correct URL anyway.
+	// Construct our GraphQL client with timeouts
 	gqlHTTPClient := &http.Client{
 		Transport: &bearerAuthTransport{
-			transport: http.DefaultTransport,
+			transport: optimizedTransport,
 			token:     cfg.Token,
 		},
-	} // We're going to wrap the Transport later in beforeInit
+		Timeout: 30 * time.Second,
+	}
 	gqlClient := githubv4.NewEnterpriseClient(apiHost.graphqlURL.String(), gqlHTTPClient)
 
 	// When a client send an initialize request, update the user agent to include the client info.

--- a/pkg/log/io.go
+++ b/pkg/log/io.go
@@ -14,6 +14,8 @@ type IOLogger struct {
 	logger *log.Logger
 }
 
+const maxLogBytes = 2048
+
 // NewIOLogger creates a new IOLogger instance
 func NewIOLogger(r io.Reader, w io.Writer, logger *log.Logger) *IOLogger {
 	return &IOLogger{
@@ -30,7 +32,13 @@ func (l *IOLogger) Read(p []byte) (n int, err error) {
 	}
 	n, err = l.reader.Read(p)
 	if n > 0 {
-		l.logger.Infof("[stdin]: received %d bytes: %s", n, string(p[:n]))
+		toLog := p[:n]
+		if len(toLog) > maxLogBytes {
+			toLog = toLog[:maxLogBytes]
+			l.logger.Infof("[stdin]: received %d bytes (truncated to %d): %s", n, maxLogBytes, string(toLog))
+		} else {
+			l.logger.Infof("[stdin]: received %d bytes: %s", n, string(toLog))
+		}
 	}
 	return n, err
 }
@@ -40,6 +48,12 @@ func (l *IOLogger) Write(p []byte) (n int, err error) {
 	if l.writer == nil {
 		return 0, io.ErrClosedPipe
 	}
-	l.logger.Infof("[stdout]: sending %d bytes: %s", len(p), string(p))
+	toLog := p
+	if len(toLog) > maxLogBytes {
+		toLog = toLog[:maxLogBytes]
+		l.logger.Infof("[stdout]: sending %d bytes (truncated to %d): %s", len(p), maxLogBytes, string(toLog))
+	} else {
+		l.logger.Infof("[stdout]: sending %d bytes: %s", len(p), string(toLog))
+	}
 	return l.writer.Write(p)
 }


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:

This PR implements several performance optimizations focused on reducing binary size, improving network operations, and lowering logging overhead.

**Key Changes & Why:**

*   **Reduced Binary Size:**
    *   Excluded the `generate_docs.go` subcommand from the main build using a `docgen` build tag.
    *   Added `-trimpath` to the Dockerfile's `go build` command.
    *   **Why:** Leads to smaller Docker images, faster deployments, and reduced memory footprint.

*   **Optimized HTTP Clients:**
    *   Introduced a shared, tuned `http.Transport` with HTTP/2 support, connection pooling, and various timeouts.
    *   Applied `http.Client` timeouts (30s) for both REST and GraphQL GitHub API clients.
    *   **Why:** Enhances network resilience, prevents hangs, improves connection reuse, and ensures more robust API interactions.

*   **Truncated IO Logging:**
    *   Limited stdin/stdout logging in `pkg/log/io.go` to a maximum of 2KB per message.
    *   **Why:** Significantly reduces CPU and I/O overhead, especially when processing large command inputs or outputs, making logs less verbose and more performant under load.

**Tradeoffs:**
*   The `generate-docs` subcommand now requires building with the `docgen` tag (e.g., `go build -tags docgen ./cmd/github-mcp-server`).
*   IO logs for very large payloads will be truncated, meaning the full content won't be visible in logs (this is an intentional part of the optimization).

**Alternatives:**
*   Considered but not implemented in this PR: adding `pprof` endpoints for detailed profiling (could be added behind a build tag), or disabling VCS info in non-release builds (`-buildvcs=false`) for marginal size reduction.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccbdf878-b24c-476f-8ee8-d3abfd4f3400">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ccbdf878-b24c-476f-8ee8-d3abfd4f3400">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

